### PR TITLE
Fix nodwwebkit package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Fuckr is a Grindr™ client for desktop built with Node-Webkit, AngularJS and a modified version of [jacasr](https://github.com/tdebarochez/jacasr) (bundled in `fuckr/node_modules`).
 
 ##Run
-Install node-webkit >= 0.12 (eg. `npm install -g nodewebkit`) and run `nw fuckr`
+Install node-webkit >= 0.12 (eg. `npm install -g nw`) and run `nw fuckr`
 
 ##Develop
 


### PR DESCRIPTION
the newest version of nodewebkit you can't install with 'npm install -g nodewebkit'; it is deprecated and installed less than the required 0.12

Running 'npm install -g nw' satisfies this dependancy